### PR TITLE
native linux 64-bit support v2

### DIFF
--- a/src/boot/platforms.r
+++ b/src/boot/platforms.r
@@ -17,7 +17,7 @@ REBOL [
 Amiga		[1 m68k20+ 2 m68k 3 ppc]
 Macintosh	[1 mac-ppc 2 mac-m68k 3 mac-misc 4 osx-ppc 5 osx-x86]
 Windows		[1 win32-x86 2 dec-alpha]
-Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 30 libc6-mips]
+Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 30 libc6-mips 40 libc-x64]
 Haiku		[75 x86-32]
 BSDi		[1 x86]
 FreeBSD		[1 x86 2 elf-x86]

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -708,7 +708,7 @@ RL_API u32 RL_Find_Word(u32 *words, u32 word)
 	return 0;
 }
 
-RL_API int RL_Series(REBSER *series, REBCNT what)
+RL_API uintptr_t RL_Series(REBSER *series, REBCNT what)
 /*
 **	Get series information.
 **
@@ -722,7 +722,7 @@ RL_API int RL_Series(REBSER *series, REBCNT what)
 */
 {
 	switch (what) {
-	case RXI_SER_DATA: return (int)SERIES_DATA(series); // problem for 64 bit !!
+	case RXI_SER_DATA: return (uintptr_t)SERIES_DATA(series);
 	case RXI_SER_TAIL: return SERIES_TAIL(series);
 	case RXI_SER_LEFT: return SERIES_AVAIL(series);
 	case RXI_SER_SIZE: return SERIES_REST(series);

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -104,21 +104,21 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 ***********************************************************************/
 {
 	int marker;
-	REBCNT bounds;
+	uintptr_t bounds;
 
 	Host_Lib = lib;
 
 	if (Host_Lib->size < HOST_LIB_SIZE) return 1;
 	if (((HOST_LIB_VER << 16) + HOST_LIB_SUM) != Host_Lib->ver_sum) return 2;
 
-	bounds = OS_CONFIG(1, 0);
-	if (bounds == 0) bounds = STACK_BOUNDS;
+	bounds = (uintptr_t)OS_CONFIG(1, 0);
+	if (bounds == 0) bounds = (uintptr_t)STACK_BOUNDS;
 
 #ifdef OS_STACK_GROWS_UP
-	Stack_Limit = (REBCNT)(&marker) + bounds;
+	Stack_Limit = (uintptr_t)(&marker) + bounds;
 #else
-	if (bounds > (REBCNT)(&marker)) Stack_Limit = 100;
-	else Stack_Limit = (REBCNT)(&marker) - bounds;
+	if (bounds > (uintptr_t) &marker) Stack_Limit = 100;
+	else Stack_Limit = (uintptr_t)&marker - bounds;
 #endif
 
 	Init_Core(rargs);

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -96,9 +96,14 @@ extern const REBYTE Str_Banner[];
 #endif
 
 	ASSERT(VAL_TYPE(&val) == 123,  RP_REBVAL_ALIGNMENT);
+#ifdef __LP64__
+	ASSERT(sizeof(REBVAL) == 32,   RP_REBVAL_ALIGNMENT);
+	ASSERT1(sizeof(REBGOB) == 84,  RP_BAD_SIZE);
+#else
 	ASSERT(sizeof(REBVAL) == 16,   RP_REBVAL_ALIGNMENT);
-	ASSERT1(sizeof(REBDAT) == 4,   RP_BAD_SIZE);
 	ASSERT1(sizeof(REBGOB) == 64,  RP_BAD_SIZE);
+#endif
+	ASSERT1(sizeof(REBDAT) == 4,   RP_BAD_SIZE);
 }
 
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -325,7 +325,7 @@ extern const REBYTE Str_Banner[];
 {
 	Action_Count++;
 	if (Action_Count >= A_MAX_ACTION) Crash(RP_ACTION_OVERFLOW);
-	Make_Native(ds, VAL_SERIES(D_ARG(1)), (REBFUN)Action_Count, REB_ACTION);
+	Make_Native(ds, VAL_SERIES(D_ARG(1)), (REBFUN)(uintptr_t)Action_Count, REB_ACTION);
 	return R_RET;
 }
 

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -71,7 +71,7 @@
 
 	cp = buf;
 	for (l = 0; l < max_lines; l++) {
-		cp = Form_Hex_Pad(cp, (REBCNT) bp, 8);
+		cp = Form_Hex_Pad(cp, (REBU64) bp, 8);
 
 		*cp++ = ':';
 		*cp++ = ' ';

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -122,7 +122,8 @@
 
 	cp = buf;
 	for (l = 0; l < count; l++) {
-		cp = Form_Hex_Pad(cp, (REBCNT) l, 4);
+		cp = Form_Hex_Pad(cp, l, 8);
+
 		*cp++ = ':';
 		*cp++ = ' ';
 

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -706,7 +706,7 @@ pick:
 
 		case 's':
 			cp = va_arg(args, REBYTE *);
-			if ((REBCNT)cp < 100) cp = (REBYTE*)Bad_Ptr;
+			if ((uintptr_t)cp < 100) cp = (REBYTE*)Bad_Ptr;
 			if (pad == 1) pad = LEN_BYTES(cp);
 			if (pad < 0) {
 				pad = -pad;
@@ -751,7 +751,7 @@ mold_value:
 			if (len + MAX_HEX_LEN + 1 < max) { // A cheat, but it is safe.
 				*bp++ = '#';
 				if (pad == 1) pad = 8;
-				cp = Form_Hex_Pad(bp, (REBCNT)(va_arg(args, REBYTE*)), pad);
+				cp = Form_Hex_Pad(bp, (REBU64)(uintptr_t)(va_arg(args, REBYTE*)), pad);
 				len += 1 + (REBCNT)(cp - bp);
 				bp = cp;
 			}

--- a/src/core/f-math.c
+++ b/src/core/f-math.c
@@ -269,11 +269,11 @@ xx*/	REBCNT Random_Int(REBFLG secure)
 		REBYTE srcbuf[20], dstbuf[20];
 		REBCNT i;
 
-		Long_To_Bytes(srcbuf, tmp);
+		REBCNT_To_Bytes(srcbuf, tmp);
 		for(i = sizeof(tmp); i < 20; i += sizeof(tmp))
 			memcpy(srcbuf + i, srcbuf, sizeof(tmp));
 		SHA1(srcbuf, i, dstbuf);
-		tmp = Bytes_To_Long(dstbuf);
+		tmp = Bytes_To_REBCNT(dstbuf);
 	}
 
 	return tmp;

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -32,27 +32,28 @@
 
 /***********************************************************************
 **
-*/	void Long_To_Bytes(REBYTE *out, REBCNT in)
+*/	void REBCNT_To_Bytes(REBYTE *out, REBCNT in)
 /*
 ***********************************************************************/
 {
+	ASSERT(sizeof(REBCNT) == 4, RP_BAD_SIZE);
 	out[0] = (REBYTE) in;
 	out[1] = (REBYTE)(in >> 8);
 	out[2] = (REBYTE)(in >> 16);
 	out[3] = (REBYTE)(in >> 24);
 }
 
-
 /***********************************************************************
 **
-*/	REBCNT Bytes_To_Long(REBYTE *in)
+*/	REBCNT Bytes_To_REBCNT(REBYTE *in)
 /*
 ***********************************************************************/
 {
-	return (REBCNT) in[0]          // & 0xFF
-	     | (REBCNT) (in[1] <<  8)  // & 0xFF00;
-	     | (REBCNT) (in[2] << 16)  // & 0xFF0000;
-	     | (REBCNT) (in[3] << 24); // & 0xFF000000;
+	ASSERT(sizeof(REBCNT) == 4, RP_BAD_SIZE);
+	return (REBCNT) in[0]         // & 0xFF
+		| (REBCNT) ((REBCNT) in[1] <<  8)  // & 0xFF00;
+		| (REBCNT) ((REBCNT) in[2] << 16)  // & 0xFF0000;
+		| (REBCNT) ((REBCNT) in[3] << 24); // & 0xFF000000;
 }
 
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -639,7 +639,7 @@ clear_header:
 			count++;
 			// The node better belong to one of the pool's segments:
 			for (seg = Mem_Pools[pool_num].segs; seg; seg = seg->next) {
-				if ((int)node > (int)seg && (int)node < (int)seg + (int)seg->size) break;
+				if ((intptr_t)node > (intptr_t)seg && (intptr_t)node < (intptr_t)seg + (intptr_t)seg->size) break;
 			}
 			if (!seg) goto crash;
 			pnode = node; // for debugger

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -420,7 +420,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	memset((REBYTE *)node, 0xff, length);
 #endif
 	series->tail = series->size = 0;
-	SERIES_REST(series) = length / wide;
+	SERIES_REST(series) = length / wide; //FIXME: This is based on the assumption that length is multiple of wide
 	series->data = (REBYTE *)node;
 	series->info = wide; // also clears flags
 	LABEL_SERIES(series, "make");

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -368,7 +368,11 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 	CHECK_STACK(&series);
 
+#ifdef __LP64__
+	if (((REBU64)length * wide) > MAX_I64) Trap0(RE_NO_MEMORY);
+#else
 	if (((REBU64)length * wide) > MAX_I32) Trap0(RE_NO_MEMORY);
+#endif
 
 	PG_Reb_Stats->Series_Made++;
 	PG_Reb_Stats->Series_Memory += length * wide;

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -64,7 +64,7 @@
 	REBCNT extra;
 	REBCNT wide;
 	REBSER *newser, swap;
-	REBCNT n;
+	uintptr_t n;
 	REBCNT x;
 
 	if (delta == 0) return;
@@ -101,21 +101,21 @@
 		// Create a new series that is bigger.
 		// Have we recently expanded the same series?
 		x = 1;
-		n = (REBCNT)(Prior_Expand[0]);
+		n = (uintptr_t)(Prior_Expand[0]);
 		do {
 			if (Prior_Expand[n] == series) {
 				x = series->tail + delta + 1; // Double the size
 				break;
 			}
 			if (++n >= MAX_EXPAND_LIST) n = 1;
-		} while (n != (REBCNT)(Prior_Expand[0]));
+		} while (n != (uintptr_t)(Prior_Expand[0]));
 #ifdef DEBUGGING
 		Print_Num("Expand:", series->tail + delta + 1);
 #endif
 		newser = Make_Series(series->tail + delta + x, wide, TRUE);
 		// If necessary, add series to the recently expanded list:
 		if (Prior_Expand[n] != series) {
-			n = (REBCNT)(Prior_Expand[0]) + 1;
+			n = (uintptr_t)(Prior_Expand[0]) + 1;
 			if (n >= MAX_EXPAND_LIST) n = 1;
 			Prior_Expand[n] = series;
 		}

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -555,7 +555,7 @@ got_err:
 	case REB_URL:
 	case REB_FILE:
 		// DO native and system/intrinsic/do must use same arg list:
-		Do_Sys_Func(SYS_CTX_DO_P, value, D_ARG(2), D_ARG(3), D_ARG(4), D_ARG(5), 0);
+		Do_Sys_Func(SYS_CTX_DO_P, value, D_ARG(2), D_ARG(3), D_ARG(4), D_ARG(5), NULL);
 		return R_TOS1;
 
 	case REB_TASK:

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -186,7 +186,7 @@ static REBCNT *CRC_Table;
 **
 ***********************************************************************/
 {
-	REBCNT	ret;
+	uintptr_t	ret; //FIXME: the return type of the function needs to be changed as well?
 
 	switch(VAL_TYPE(val)) {
 
@@ -240,7 +240,7 @@ static REBCNT *CRC_Table;
 		break;
 
 	case REB_OBJECT:
-		ret = ((REBCNT)VAL_OBJ_FRAME(val)) >> 4;
+		ret = ((uintptr_t)VAL_OBJ_FRAME(val)) >> 4;
 		break;
 
 	case REB_DATATYPE:

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -206,7 +206,9 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	REBCNT out = index;
 	REBOOL append_line_feed = FALSE;
 	REBUNI uc;
-
+	if (tail == index){
+		return;
+	}
 	// Skip head lines if required:
 	if (h || !t) {
 		for (; index < tail; index++) {

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -422,7 +422,7 @@ const REBCNT Gob_Flag_Words[] = {
 		}
 		else if (IS_INTEGER(val)) {
 			SET_GOB_DTYPE(gob, GOBD_INTEGER);
-			SET_GOB_DATA(gob, (void*)VAL_INT32(val));
+			SET_GOB_DATA(gob, (void*)(intptr_t)VAL_INT32(val));
 		}
 		else if (IS_NONE(val))
 			SET_GOB_TYPE(gob, GOBT_NONE);
@@ -541,7 +541,7 @@ is_none:
 			SET_BINARY(val, GOB_DATA(gob));
 		}
 		else if (GOB_DTYPE(gob) == GOBD_INTEGER) {
-			SET_INTEGER(val, (REBINT)GOB_DATA(gob));
+			SET_INTEGER(val, (REBINT)(intptr_t)GOB_DATA(gob));
 		}
 		else goto is_none;
 		break;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -121,10 +121,15 @@
 		break;
 
 	case A_MULTIPLY:
-		anum = num * arg;
-		if (((num != 0) && (anum / num != arg)) || ((anum == arg) && (arg != 0) && (num != 1)))
+		if ((num > 0 && arg < 0 && arg < MIN_I64 / num)
+			|| (num > 0 && arg > 0 && num > MAX_I64 / arg)
+			|| (num < 0 && arg < 0 && num < MAX_I64 / arg)
+			|| (num < 0 && arg > 0 && num < MIN_I64 / arg)){
 			Trap0(RE_OVERFLOW);
-		num = anum;
+		} else {
+			num *= arg;
+		}
+
 		break;
 
 	case A_DIVIDE:

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -71,7 +71,7 @@
 **
 ***********************************************************************/
 {
-	REBCNT size;
+	uLongf size;
 	REBSER *output;
 	REBINT err;
 	REBYTE out_size[4];
@@ -108,7 +108,7 @@
 **
 ***********************************************************************/
 {
-	REBCNT size;
+	uLongf size;
 	REBSER *output;
 	REBINT err;
 

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -74,7 +74,7 @@
 	uLongf size;
 	REBSER *output;
 	REBINT err;
-	REBYTE out_size[4];
+	REBYTE out_size[sizeof(REBCNT)];
 
 	if (len < 0) Trap0(RE_PAST_END); // !!! better msg needed
 	size = len + (len > STERLINGS_MAGIC_NUMBER ? len / 10 + 12 : STERLINGS_MAGIC_FIX);
@@ -90,8 +90,8 @@
 	}
 	SET_STR_END(output, size);
 	SERIES_TAIL(output) = size;
-	Long_To_Bytes(out_size, (REBCNT)len); // Tag the size to the end.
-	Append_Series(output, (REBYTE*)out_size, 4);
+	REBCNT_To_Bytes(out_size, (REBCNT)len); // Tag the size to the end.
+	Append_Series(output, (REBYTE*)out_size, sizeof(REBCNT));
 	if (SERIES_AVAIL(output) > 1024) // Is there wasted space?
 		output = Copy_Series(output); // Trim it down if too big. !!! Revisit this based on mem alloc alg.
 	//ENABLE_GC;
@@ -116,7 +116,7 @@
 
 	// Get the size from the end and make the output buffer that size.
 	if (len <= 4) Trap0(RE_PAST_END); // !!! better msg needed
-	size = Bytes_To_Long(BIN_SKIP(input, len) - 4);
+	size = Bytes_To_REBCNT(BIN_SKIP(input, len) - sizeof(REBCNT));
 
 	if (limit && size > limit) Trap_Num(RE_SIZE_LIMIT, size); 
 

--- a/src/core/u-sha1.c
+++ b/src/core/u-sha1.c
@@ -78,19 +78,21 @@ extern "C" {
 #define SHA_LENGTH_BLOCK 8
 #define SHA_DIGEST_LENGTH 20
 
+#define SHA_LONG u32
+
 typedef struct SHAstate_st
 	{
-	unsigned long h0,h1,h2,h3,h4;
-	unsigned long Nl,Nh;
-	unsigned long data[SHA_LBLOCK];
-	int num;
+	SHA_LONG h0,h1,h2,h3,h4;
+	SHA_LONG Nl,Nh;
+	SHA_LONG data[SHA_LBLOCK];
+	unsigned int num;
 	} SHA_CTX;
 
 void SHA1_Init(SHA_CTX *c);
-void SHA1_Update(SHA_CTX *c, unsigned char *data, unsigned long len);
+void SHA1_Update(SHA_CTX *c, unsigned char *data, size_t len);
 void SHA1_Final(unsigned char *md, SHA_CTX *c);
 int SHA1_CtxSize(void);
-//unsigned char *SHA1(unsigned char *d, unsigned long n,unsigned char *md);
+//unsigned char *SHA1(unsigned char *d, SHA_LONG n,unsigned char *md);
 //static void SHA1_Transform(SHA_CTX *c, unsigned char *data);
 
 #ifdef  __cplusplus
@@ -98,7 +100,7 @@ int SHA1_CtxSize(void);
 #endif
 
 
-#define ULONG	unsigned long
+#define ULONG	SHA_LONG
 #define UCHAR	unsigned char
 #define UINT	unsigned int
 
@@ -107,18 +109,18 @@ int SHA1_CtxSize(void);
 #endif
 
 #undef c2nl
-#define c2nl(c,l)	(l =(((unsigned long)(*((c)++)))<<24), \
-			 l|=(((unsigned long)(*((c)++)))<<16), \
-			 l|=(((unsigned long)(*((c)++)))<< 8), \
-			 l|=(((unsigned long)(*((c)++)))    ))
+#define c2nl(c,l)	(l =(((SHA_LONG)(*((c)++)))<<24), \
+			 l|=(((SHA_LONG)(*((c)++)))<<16), \
+			 l|=(((SHA_LONG)(*((c)++)))<< 8), \
+			 l|=(((SHA_LONG)(*((c)++)))    ))
 
 #undef p_c2nl
 #define p_c2nl(c,l,n)	{ \
 			switch (n) { \
-			case 0: l =((unsigned long)(*((c)++)))<<24; \
-			case 1: l|=((unsigned long)(*((c)++)))<<16; \
-			case 2: l|=((unsigned long)(*((c)++)))<< 8; \
-			case 3: l|=((unsigned long)(*((c)++))); \
+			case 0: l =((SHA_LONG)(*((c)++)))<<24; \
+			case 1: l|=((SHA_LONG)(*((c)++)))<<16; \
+			case 2: l|=((SHA_LONG)(*((c)++)))<< 8; \
+			case 3: l|=((SHA_LONG)(*((c)++))); \
 				} \
 			}
 
@@ -128,9 +130,9 @@ int SHA1_CtxSize(void);
 			l=0; \
 			(c)+=n; \
 			switch (n) { \
-			case 3: l =((unsigned long)(*(--(c))))<< 8; \
-			case 2: l|=((unsigned long)(*(--(c))))<<16; \
-			case 1: l|=((unsigned long)(*(--(c))))<<24; \
+			case 3: l =((SHA_LONG)(*(--(c))))<< 8; \
+			case 2: l|=((SHA_LONG)(*(--(c))))<<16; \
+			case 1: l|=((SHA_LONG)(*(--(c))))<<24; \
 				} \
 			}
 
@@ -138,11 +140,11 @@ int SHA1_CtxSize(void);
 #define p_c2nl_p(c,l,sc,len) { \
 			switch (sc) \
 				{ \
-			case 0: l =((unsigned long)(*((c)++)))<<24; \
+			case 0: l =((SHA_LONG)(*((c)++)))<<24; \
 				if (--len == 0) break; \
-			case 1: l|=((unsigned long)(*((c)++)))<<16; \
+			case 1: l|=((SHA_LONG)(*((c)++)))<<16; \
 				if (--len == 0) break; \
-			case 2: l|=((unsigned long)(*((c)++)))<< 8; \
+			case 2: l|=((SHA_LONG)(*((c)++)))<< 8; \
 				} \
 			}
 
@@ -153,18 +155,18 @@ int SHA1_CtxSize(void);
 			 *((c)++)=(unsigned char)(((l)    )&0xff))
 
 #undef c2l
-#define c2l(c,l)	(l =(((unsigned long)(*((c)++)))    ), \
-			 l|=(((unsigned long)(*((c)++)))<< 8), \
-			 l|=(((unsigned long)(*((c)++)))<<16), \
-			 l|=(((unsigned long)(*((c)++)))<<24))
+#define c2l(c,l)	(l =(((SHA_LONG)(*((c)++)))    ), \
+			 l|=(((SHA_LONG)(*((c)++)))<< 8), \
+			 l|=(((SHA_LONG)(*((c)++)))<<16), \
+			 l|=(((SHA_LONG)(*((c)++)))<<24))
 
 #undef p_c2l
 #define p_c2l(c,l,n)	{ \
 			switch (n) { \
-			case 0: l =((unsigned long)(*((c)++))); \
-			case 1: l|=((unsigned long)(*((c)++)))<< 8; \
-			case 2: l|=((unsigned long)(*((c)++)))<<16; \
-			case 3: l|=((unsigned long)(*((c)++)))<<24; \
+			case 0: l =((SHA_LONG)(*((c)++))); \
+			case 1: l|=((SHA_LONG)(*((c)++)))<< 8; \
+			case 2: l|=((SHA_LONG)(*((c)++)))<<16; \
+			case 3: l|=((SHA_LONG)(*((c)++)))<<24; \
 				} \
 			}
 
@@ -174,9 +176,9 @@ int SHA1_CtxSize(void);
 			l=0; \
 			(c)+=n; \
 			switch (n) { \
-			case 3: l =((unsigned long)(*(--(c))))<<16; \
-			case 2: l|=((unsigned long)(*(--(c))))<< 8; \
-			case 1: l|=((unsigned long)(*(--(c)))); \
+			case 3: l =((SHA_LONG)(*(--(c))))<<16; \
+			case 2: l|=((SHA_LONG)(*(--(c))))<< 8; \
+			case 1: l|=((SHA_LONG)(*(--(c)))); \
 				} \
 			}
 
@@ -184,11 +186,11 @@ int SHA1_CtxSize(void);
 #define p_c2l_p(c,l,sc,len) { \
 			switch (sc) \
 				{ \
-			case 0: l =((unsigned long)(*((c)++))); \
+			case 0: l =((SHA_LONG)(*((c)++))); \
 				if (--len == 0) break; \
-			case 1: l|=((unsigned long)(*((c)++)))<< 8; \
+			case 1: l|=((SHA_LONG)(*((c)++)))<< 8; \
 				if (--len == 0) break; \
-			case 2: l|=((unsigned long)(*((c)++)))<<16; \
+			case 2: l|=((SHA_LONG)(*((c)++)))<<16; \
 				} \
 			}
 
@@ -204,7 +206,7 @@ int SHA1_CtxSize(void);
 #else
 #if defined(TO_AMIGA_OLD)
 #define ROTATE(a,n) __builtin_rol(a,n,2)
-unsigned long __builtin_rol(unsigned long,int,int);
+SHA_LONG __builtin_rol(SHA_LONG,int,int);
 #else
 #define ROTATE(a,n)     (((a)<<(n))|(((a)&0xffffffff)>>(32-(n))))
 #endif
@@ -216,14 +218,14 @@ unsigned long __builtin_rol(unsigned long,int,int);
 /* 5 instructions with rotate instruction, else 9 */
 #define Endian_Reverse32(a) \
 	{ \
-	unsigned long l=(a); \
+	SHA_LONG l=(a); \
 	(a)=((ROTATE(l,8)&0x00FF00FF)|(ROTATE(l,24)&0xFF00FF00)); \
 	}
 #else
 /* 6 instructions with rotate instruction, else 8 */
 #define Endian_Reverse32(a) \
 	{ \
-	unsigned long l=(a); \
+	SHA_LONG l=(a); \
 	l=(((l&0xFF00FF00)>>8L)|((l&0x00FF00FF)<<8L)); \
 	(a)=ROTATE(l,16L); \
 	}
@@ -280,11 +282,11 @@ unsigned long __builtin_rol(unsigned long,int,int);
 /* Implemented from SHA-1 document - The Secure Hash Algorithm
  */
 
-#define INIT_DATA_h0 (unsigned long)0x67452301L
-#define INIT_DATA_h1 (unsigned long)0xefcdab89L
-#define INIT_DATA_h2 (unsigned long)0x98badcfeL
-#define INIT_DATA_h3 (unsigned long)0x10325476L
-#define INIT_DATA_h4 (unsigned long)0xc3d2e1f0L
+#define INIT_DATA_h0 (SHA_LONG)0x67452301L
+#define INIT_DATA_h1 (SHA_LONG)0xefcdab89L
+#define INIT_DATA_h2 (SHA_LONG)0x98badcfeL
+#define INIT_DATA_h3 (SHA_LONG)0x10325476L
+#define INIT_DATA_h4 (SHA_LONG)0xc3d2e1f0L
 
 #define K_00_19	0x5a827999L
 #define K_20_39 0x6ed9eba1L
@@ -292,10 +294,10 @@ unsigned long __builtin_rol(unsigned long,int,int);
 #define K_60_79 0xca62c1d6L
 
 #  ifdef SHA1_ASM
-     void sha1_block_x86(SHA_CTX *c, register unsigned long *p, int num);
+     void sha1_block_x86(SHA_CTX *c, register SHA_LONG *p, int num);
 #    define sha1_block sha1_block_x86
 #  else
-     static void sha1_block(SHA_CTX *c, register unsigned long *p, int num);
+     static void sha1_block(SHA_CTX *c, register SHA_LONG *p, int num);
 #  endif
 
 
@@ -329,7 +331,7 @@ SHA_CTX *c;
 void SHA1_Update(c, data, len)
 SHA_CTX *c;
 register unsigned char *data;
-unsigned long len;
+size_t len;
 	{
 	register ULONG *p;
 	int ew,ec,sw,sc;
@@ -337,7 +339,7 @@ unsigned long len;
 
 	if (len == 0) return;
 
-	l=(c->Nl+(len<<3))&0xffffffffL;
+	l=(c->Nl+((SHA_LONG)len<<3))&(SHA_LONG)-1;
 	if (l < c->Nl) /* overflow */
 		c->Nh++;
 	c->Nh+=(len>>29);
@@ -399,7 +401,7 @@ unsigned long len;
 	 * the C version as well....
 	 */
 #if defined(ENDIAN_BIG) || defined(SHA1_ASM)
-	if ((((unsigned long)data)%sizeof(ULONG)) == 0)
+	if ((((SHA_LONG)data)%sizeof(ULONG)) == 0)
 		{
 		sw=len/SHA_CBLOCK;
 		if (sw)
@@ -417,7 +419,7 @@ unsigned long len;
 	while (len >= SHA_CBLOCK)
 		{
 #if defined(ENDIAN_BIG) || defined(ENDIAN_LITTLE)
-		if (p != (unsigned long *)data)
+		if (p != (SHA_LONG *)data)
 			memcpy(p,data,SHA_CBLOCK);
 		data+=SHA_CBLOCK;
 #  ifdef ENDIAN_LITTLE
@@ -500,7 +502,7 @@ unsigned char *b;
 
 static void sha1_block(c, W, num)
 SHA_CTX *c;
-register unsigned long *W;
+register SHA_LONG *W;
 int num;
 	{
 	register ULONG A,B,C,D,E,T;

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -54,8 +54,17 @@ typedef char            i8;
 typedef unsigned char   u8;
 typedef short           i16;
 typedef unsigned short  u16;
+#ifdef __LP64__
+typedef int            i32;
+typedef unsigned int   u32;
+typedef long			intptr_t;
+typedef unsigned long	uintptr_t;
+#else
 typedef long            i32;
 typedef unsigned long   u32;
+typedef int				intptr_t;
+typedef unsigned int	uintptr_t;
+#endif
 
 #ifndef DEF_UINT		// some systems define it, don't define it again
 typedef unsigned int    uint;
@@ -80,8 +89,8 @@ typedef unsigned long long u64;
 // (Note: compatible with FILETIME used in Windows)
 #pragma pack(4)
 typedef struct sInt64 {
-	long l;
-	long h;
+	i32 l;
+	i32 h;
 } I64;
 #pragma pack()
 
@@ -91,12 +100,12 @@ typedef struct sInt64 {
 **
 ***********************************************************************/
 
-typedef int             REBINT;     // 32 bit (64 bit defined below)
-typedef unsigned int    REBCNT;     // 32 bit (counting number)
+typedef i32             REBINT;     // 32 bit (64 bit defined below)
+typedef u32    			REBCNT;     // 32 bit (counting number)
 typedef i64             REBI64;     // 64 bit integer
 typedef u64             REBU64;     // 64 bit unsigned integer
 typedef char            REBOOL;     // 8  bit flag (for struct usage)
-typedef unsigned int    REBFLG;     // 32 bit flag (for cpu efficiency)
+typedef u32    			REBFLG;     // 32 bit flag (for cpu efficiency)
 typedef float           REBD32;     // 32 bit decimal
 typedef double          REBDEC;     // 64 bit decimal
 

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -150,6 +150,14 @@ These are now obsolete (as of A107) and should be removed:
 #define HAS_LL_CONSTS
 #endif
 
+#ifdef TO_LINUX_X64				// Linux/AMD64
+#define ENDIAN_LITTLE
+#define HAS_LL_CONSTS
+#ifndef __LP64__
+#define __LP64__
+#endif
+#endif
+
 #ifdef TO_LINUX_PPC				// Linux/PPC
 #define ENDIAN_BIG
 #define HAS_LL_CONSTS

--- a/src/include/reb-event.h
+++ b/src/include/reb-event.h
@@ -26,7 +26,7 @@
 **
 ***********************************************************************/
 
-// Note: size must be 12 bytes!
+// Note: size must be 12 bytes on 32-bit or 16 on 64-bit!
 
 #pragma pack(4)
 typedef struct rebol_event {

--- a/src/include/reb-value.h
+++ b/src/include/reb-value.h
@@ -50,7 +50,6 @@ typedef struct rebol_word {
 } REBWRD;
 
 struct rebol_value {
-	REBINT flags;
 	union REBOL_Val_Data {
 		REBI64	integer;
 		REBINT	int32;
@@ -61,6 +60,7 @@ struct rebol_value {
 		REBWRD	word;
 		REBSRI	series;
 	} data;
+	REBINT flags;
 };
 
 #define VAL_TYPE(v)			((REBYTE)((v)->flags))	// get only the type, not flags

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -356,9 +356,9 @@ enum encoding_opts {
 #endif
 
 #ifdef OS_STACK_GROWS_UP
-#define CHECK_STACK(v) if ((REBCNT)(v) >= Stack_Limit) Trap_Stack();
+#define CHECK_STACK(v) if ((uintptr_t)(v) >= Stack_Limit) Trap_Stack();
 #else
-#define CHECK_STACK(v) if ((REBCNT)(v) <= Stack_Limit) Trap_Stack();
+#define CHECK_STACK(v) if ((uintptr_t)(v) <= Stack_Limit) Trap_Stack();
 #endif
 #define STACK_BOUNDS (4*1024*1000) // note: need a better way to set it !!
 // Also: made somewhat smaller than linker setting to allow trapping it

--- a/src/include/sys-deci-funcs.h
+++ b/src/include/sys-deci-funcs.h
@@ -57,7 +57,7 @@ REBINT deci_to_string(REBYTE *string, const deci a, const REBYTE symbol, const R
 REBYTE *deci_to_binary(REBYTE binary[12], const deci a);
 
 /* math functions */
-deci deci_ldexp (deci a, int e);
+deci deci_ldexp (deci a, REBINT e);
 deci deci_truncate (deci a, deci b);
 deci deci_away (deci a, deci b);
 deci deci_floor (deci a, deci b);

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -85,7 +85,7 @@ TVAR REBINT	GC_Last_Infant;	// Index to last infant above (circular)
 TVAR REBFLG GC_Stay_Dirty;  // Do not free memory, fill it with 0xBB
 TVAR REBSER **Prior_Expand;	// Track prior series expansions (acceleration)
 
-TVAR REBCNT Stack_Limit;	// Limit address for CPU stack.
+TVAR uintptr_t Stack_Limit;	// Limit address for CPU stack.
 
 //-- Evaluation stack:
 TVAR REBSER	*DS_Series;

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1115,6 +1115,9 @@ typedef struct Reb_All {
 		REBHAN  handle;
 		REBALL  all;
 	} data;
+#ifdef __LP64__
+	REBINT	padding; //make it 32-bit
+#endif
 };
 
 #define ANY_SERIES(v)		(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_LIT_PATH)

--- a/src/os/host-device.c
+++ b/src/os/host-device.c
@@ -187,7 +187,7 @@ static int Poll_Default(REBDEV *dev)
 
 /***********************************************************************
 **
-*/	void Done_Device(int handle, int error)
+*/	void Done_Device(uintptr_t handle, int error)
 /*
 **		Given a handle mark the related request as done.
 **		(Used by DNS device).
@@ -204,7 +204,7 @@ static int Poll_Default(REBDEV *dev)
 		prior = &dev->pending;
 		// Scan the pending requests, mark the one we got:
 		for (req = *prior; req; req = *prior) {
-			if ((int)(req->handle) == handle) {
+			if ((uintptr_t)(req->handle) == handle) {
 				req->error = error; // zero when no error
 				SET_FLAG(req->flags, RRF_DONE);
 				return;

--- a/src/tools/make-reb-lib.r
+++ b/src/tools/make-reb-lib.r
@@ -236,7 +236,11 @@ form-header/gen "REBOL Host and Extension API" %reb-lib.r %make-reb-lib.r
 // Compatiblity with the lib requires that structs are aligned using the same
 // method. This is concrete, not abstract. The macro below uses struct
 // sizes to inform the developer that something is wrong.
+#ifdef __LP64__
+#define CHECK_STRUCT_ALIGN (sizeof(REBREQ) == 100 && sizeof(REBEVT) == 16)
+#else
 #define CHECK_STRUCT_ALIGN (sizeof(REBREQ) == 80 && sizeof(REBEVT) == 12)
+#endif
 
 // Function entry points for reb-lib (used for MACROS below):}
 rlib

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -30,6 +30,7 @@ systems: [
 	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
 	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
 	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
+	[0.4.40 "linux_x64"  posix  [+O2 HID LDL ST1 -LM]]
 	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
 	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
 	[0.9.04 "openbsd"    posix  [+O1 C++ ST1 -LM]]


### PR DESCRIPTION
Here is new results (v2) compared with 32-bit binary compiled from rebolsource/master, two progressions, no regressions:

--- r_2_101_0_4_4_B67154_4E5726.log 2013-08-27 13:15:39.886715794 -0400
+++ r_2_101_0_4_40_23D80F_4E5726.log    2013-08-27 12:38:10.306708383 -0400
@@ -4849,13 +4849,13 @@
 [0.1 == round/half-down/to 0.15 0.1] "succeeded"
 [0.2 == round/half-down/to 0.15001 0.1] "succeeded"
 [0.5 == round/half-down/to 0.55 0.1] "succeeded"
-[0.6 == round/half-down/to 0.55001 0.1] "failed"
+[0.6 == round/half-down/to 0.55001 0.1] "succeeded"
 [0.5 == round/half-down/to 0.75 0.5] "succeeded"
 [1.0 == round/half-down/to 0.75001 0.5] "succeeded"
 [-0.1 == round/half-down/to -0.15 0.1] "succeeded"
 [-0.2 == round/half-down/to -0.15001 0.1] "succeeded"
 [-0.5 == round/half-down/to -0.55 0.1] "succeeded"
-[-0.6 == round/half-down/to -0.55001 0.1] "failed"
+[-0.6 == round/half-down/to -0.55001 0.1] "succeeded"
 [-0.5 == round/half-down/to -0.75 0.5] "succeeded"
 [-1.0 == round/half-down/to -0.75001 0.5] "succeeded"
 [0 = sign? 0] "succeeded"
@@ -8463,12 +8463,12 @@
 ] "failed, error was caused in the test code"
 [equal? read write clipboard:// c: "test" c] "failed, error was caused in the test code"

-system/version: 2.101.0.4.4
-code-checksum: #{B67154A19B8BCC7C977D2CCE0C9E43B395389CBC}
+system/version: 2.101.0.4.40
+code-checksum: #{23D80F69007D034B0DD66F548523D4556183DD63}
 test-checksum: #{4E5726B3CE4645AC5EAB8AF08F677090E0998DD3}
 Total: 4696
-Succeeded: 4212
-Test-failures: 160
+Succeeded: 4214
+Test-failures: 158
 Crashes: 16
 Dialect-failures: 0
 Skipped: 308
