### PR TITLE
Fix buffer overflow in RL_Word_String()

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -680,7 +680,7 @@ RL_API REBYTE *RL_Word_String(u32 word)
 	// !!This code should use a function from c-words.c (but nothing perfect yet.)
 	if (word == 0 || word >= PG_Word_Table.series->tail) return 0;
 	s1 = VAL_SYM_NAME(BLK_SKIP(PG_Word_Table.series, word));
-	s2 = OS_MAKE(strlen(s1));
+	s2 = OS_MAKE(strlen(s1) + 1);
 	strcpy(s2, s1);
 	return s2;
 }


### PR DESCRIPTION
Such off-by-one error rarely manifests itself in real use, but a synthetic test crashes the interpreter.
